### PR TITLE
feat: Jellyfin Multi-Version naming

### DIFF
--- a/MediaHub/config/config.py
+++ b/MediaHub/config/config.py
@@ -176,6 +176,12 @@ def is_skip_patterns_enabled():
 def is_skip_versions_enabled():
     return os.getenv('SKIP_VERSIONS', 'true').lower() in ['true', '1', 'yes']
 
+def is_jellyfin_multi_version_enabled():
+    """Check if Jellyfin multi-version naming is enabled.
+    When enabled, multiple versions of the same movie are named with a
+    ' - label' suffix (e.g. resolution) so Jellyfin groups them together."""
+    return os.getenv('JELLYFIN_MULTI_VERSION', 'false').lower() in ['true', '1', 'yes']
+
 def is_rclone_mount_enabled():
     return os.getenv('RCLONE_MOUNT', 'false').lower() == 'true'
 

--- a/MediaHub/processors/movie_processor.py
+++ b/MediaHub/processors/movie_processor.py
@@ -8,7 +8,7 @@ from MediaHub.utils.logging_utils import log_message
 from MediaHub.config.config import *
 from MediaHub.utils.mediainfo_extractor import *
 from MediaHub.api.tmdb_api_helpers import get_movie_data
-from MediaHub.processors.symlink_utils import load_skip_patterns, should_skip_file, _extract_version_label
+from MediaHub.processors.symlink_utils import load_skip_patterns, should_skip_file, _extract_version_label, _extract_detailed_version_label
 from MediaHub.utils.meta_extraction_engine import get_ffprobe_media_info
 from MediaHub.processors.db_utils import track_file_failure
 
@@ -592,6 +592,12 @@ def process_movie(src_file, root, file, dest_dir, actual_dir, tmdb_folder_id_ena
             version_label = ext.lstrip('.').upper()
 
         dest_file = os.path.join(dest_path, f"{clean_movie_folder} - {version_label}{ext}")
+
+        # If short label conflicts, try a more detailed label (e.g. "1080p BluRay" vs "1080p WEB-DL")
+        if os.path.exists(dest_file):
+            detailed_label = _extract_detailed_version_label(file)
+            if detailed_label and detailed_label != version_label:
+                dest_file = os.path.join(dest_path, f"{clean_movie_folder} - {detailed_label}{ext}")
 
     # Extract clean name from proper_name which may include TMDB/IMDB IDs
     clean_name = proper_name

--- a/MediaHub/processors/movie_processor.py
+++ b/MediaHub/processors/movie_processor.py
@@ -585,9 +585,13 @@ def process_movie(src_file, root, file, dest_dir, actual_dir, tmdb_folder_id_ena
     # Apply Jellyfin multi-version label if enabled
     if is_jellyfin_multi_version_enabled():
         version_label = _extract_version_label(file)
-        if version_label:
-            name_no_ext, ext = os.path.splitext(new_name)
-            dest_file = os.path.join(dest_path, f"{clean_movie_folder} - {version_label}{ext}")
+        ext = os.path.splitext(new_name)[1]
+
+        # Fall back to container format (e.g. "MKV", "AVI") when no quality info in filename
+        if not version_label:
+            version_label = ext.lstrip('.').upper()
+
+        dest_file = os.path.join(dest_path, f"{clean_movie_folder} - {version_label}{ext}")
 
     # Extract clean name from proper_name which may include TMDB/IMDB IDs
     clean_name = proper_name

--- a/MediaHub/processors/movie_processor.py
+++ b/MediaHub/processors/movie_processor.py
@@ -8,7 +8,7 @@ from MediaHub.utils.logging_utils import log_message
 from MediaHub.config.config import *
 from MediaHub.utils.mediainfo_extractor import *
 from MediaHub.api.tmdb_api_helpers import get_movie_data
-from MediaHub.processors.symlink_utils import load_skip_patterns, should_skip_file
+from MediaHub.processors.symlink_utils import load_skip_patterns, should_skip_file, _extract_version_label
 from MediaHub.utils.meta_extraction_engine import get_ffprobe_media_info
 from MediaHub.processors.db_utils import track_file_failure
 
@@ -578,6 +578,13 @@ def process_movie(src_file, root, file, dest_dir, actual_dir, tmdb_folder_id_ena
         new_name = file
 
     dest_file = os.path.join(dest_path, new_name)
+
+    # Apply Jellyfin multi-version label if enabled
+    if is_jellyfin_multi_version_enabled():
+        version_label = _extract_version_label(file)
+        if version_label:
+            name_no_ext, ext = os.path.splitext(new_name)
+            dest_file = os.path.join(dest_path, f"{movie_folder} - {version_label}{ext}")
 
     # Extract clean name from proper_name which may include TMDB/IMDB IDs
     clean_name = proper_name

--- a/MediaHub/processors/movie_processor.py
+++ b/MediaHub/processors/movie_processor.py
@@ -419,6 +419,9 @@ def process_movie(src_file, root, file, dest_dir, actual_dir, tmdb_folder_id_ena
     # Extract media information for renaming
     media_info = extract_media_info(file, keywords)
 
+    # Save clean folder name before bracket tags are appended (used by Jellyfin multi-version naming)
+    clean_movie_folder = movie_folder
+
     # Optionally append extracted media information to movie folder name
     if media_info:
         if 'Resolution' in media_info:
@@ -584,7 +587,7 @@ def process_movie(src_file, root, file, dest_dir, actual_dir, tmdb_folder_id_ena
         version_label = _extract_version_label(file)
         if version_label:
             name_no_ext, ext = os.path.splitext(new_name)
-            dest_file = os.path.join(dest_path, f"{movie_folder} - {version_label}{ext}")
+            dest_file = os.path.join(dest_path, f"{clean_movie_folder} - {version_label}{ext}")
 
     # Extract clean name from proper_name which may include TMDB/IMDB IDs
     clean_name = proper_name

--- a/MediaHub/processors/symlink_utils.py
+++ b/MediaHub/processors/symlink_utils.py
@@ -17,31 +17,62 @@ from MediaHub.utils.plex_utils import update_plex_after_deletion
 from MediaHub.config.config import is_skip_versions_enabled, is_jellyfin_multi_version_enabled
 import re
 
+# Load keywords once at module level
+_KEYWORDS_FILE = os.path.join(os.path.dirname(__file__), '..', 'utils', 'keywords.json')
+_keywords_cache = None
+
+def _load_keywords():
+	global _keywords_cache
+	if _keywords_cache is None:
+		try:
+			with open(_KEYWORDS_FILE, 'r') as f:
+				_keywords_cache = json.load(f)
+		except (IOError, json.JSONDecodeError) as e:
+			log_message(f"Failed to load keywords.json: {e}", level="WARNING")
+			_keywords_cache = {}
+	return _keywords_cache
+
 def _extract_version_parts(filepath):
 	"""Extract all version parts (resolution, quality source, edition) from a file path.
 	
+	Uses editions and quality_sources from keywords.json for matching.
 	Returns a list of matched parts in priority order, e.g. ['1080p', 'BluRay'] or ['Extended'].
 	"""
 	basename = os.path.basename(filepath)
+	# Normalize separators for matching
+	normalized = basename.replace('.', ' ').replace('_', ' ')
 	parts = []
+	keywords = _load_keywords()
 	
-	# Resolution (e.g., 2160p, 1080p, 720p, 480p)
-	res_match = re.search(r'\b(2160p|1080p|720p|480p|360p|4K)\b', basename, re.IGNORECASE)
-	if res_match:
-		label = res_match.group(1)
-		if label.upper() == '4K':
-			label = '2160p'
-		parts.append(label)
+	# Resolution from keywords.json (e.g., 2160p, 1080p, 720p, 480p)
+	resolutions = keywords.get('resolutions', [])
+	if resolutions:
+		res_pattern = r'\b(' + '|'.join(re.escape(r) for r in resolutions) + r')\b'
+		res_match = re.search(res_pattern, basename, re.IGNORECASE)
+		if res_match:
+			label = res_match.group(1)
+			if label.upper() == '4K':
+				label = '2160p'
+			parts.append(label)
 	
-	# Quality source (e.g., Remux, BluRay, WEB-DL, HDTV)
-	quality_match = re.search(r'\b(Remux|BluRay|Blu-Ray|WEB-DL|WEBRip|HDTV|HDRip|DVDRip|BDRip|BRRip)\b', basename, re.IGNORECASE)
-	if quality_match:
-		parts.append(quality_match.group(1))
+	# Quality source from keywords.json
+	quality_sources = keywords.get('quality_sources', [])
+	if quality_sources:
+		# Sort by length descending so longer matches win (e.g. "WEB-DL" before "BD")
+		for qs in sorted(quality_sources, key=len, reverse=True):
+			if re.search(r'\b' + re.escape(qs) + r'\b', basename, re.IGNORECASE):
+				parts.append(qs)
+				break
 	
-	# Edition tags (e.g., Directors Cut, Extended, Theatrical)
-	edition_match = re.search(r"\b(Director'?s?[\s.]?Cut|Extended|Theatrical|Unrated|Uncut|Remastered|IMAX)\b", basename, re.IGNORECASE)
-	if edition_match:
-		parts.append(edition_match.group(1).replace('.', ' ').replace('_', ' '))
+	# Edition from keywords.json
+	editions = keywords.get('editions', [])
+	if editions:
+		for edition in sorted(editions, key=len, reverse=True):
+			# Normalize both sides: strip apostrophes/special chars for matching
+			norm_edition = edition.replace("'", "").replace("\u2019", "")
+			if re.search(r'\b' + re.escape(norm_edition) + r'\b', normalized.replace("'", ""), re.IGNORECASE):
+				parts.append(edition)
+				break
 	
 	return parts
 

--- a/MediaHub/processors/symlink_utils.py
+++ b/MediaHub/processors/symlink_utils.py
@@ -14,7 +14,44 @@ from MediaHub.utils.file_utils import get_symlink_target_path
 from MediaHub.utils.webdav_api import send_structured_message, send_file_deletion
 from MediaHub.api.media_cover import cleanup_tmdb_covers
 from MediaHub.utils.plex_utils import update_plex_after_deletion
-from MediaHub.config.config import is_skip_versions_enabled
+from MediaHub.config.config import is_skip_versions_enabled, is_jellyfin_multi_version_enabled
+import re
+
+def _extract_version_label(filepath):
+	"""Extract a version label (resolution or edition) from a file path for Jellyfin multi-version naming.
+	
+	Returns a label string like '2160p', '1080p', '720p', 'Remux', etc.
+	Falls back to a generic label if nothing can be extracted.
+	"""
+	basename = os.path.basename(filepath)
+	
+	# Try to extract resolution (e.g., 2160p, 1080p, 720p, 480p)
+	res_match = re.search(r'\b(2160p|1080p|720p|480p|360p|4K)\b', basename, re.IGNORECASE)
+	if res_match:
+		label = res_match.group(1)
+		# Normalize 4K to 2160p for consistent sorting
+		if label.upper() == '4K':
+			label = '2160p'
+		return label
+	
+	# Try to extract quality source (e.g., Remux, BluRay, WEB-DL, HDTV)
+	quality_match = re.search(r'\b(Remux|BluRay|Blu-Ray|WEB-DL|WEBRip|HDTV|HDRip|DVDRip|BDRip|BRRip)\b', basename, re.IGNORECASE)
+	if quality_match:
+		return quality_match.group(1)
+	
+	# Try edition tags (e.g., Directors Cut, Extended, Theatrical)
+	edition_match = re.search(r"\b(Director'?s?[\s.]?Cut|Extended|Theatrical|Unrated|Uncut|Remastered|IMAX)\b", basename, re.IGNORECASE)
+	if edition_match:
+		# Normalize dots/underscores to spaces in the label
+		return edition_match.group(1).replace('.', ' ').replace('_', ' ')
+	
+	return None
+
+def _jellyfin_version_name(folder_name, label, ext):
+	"""Build a Jellyfin multi-version filename: 'FolderName - Label.ext'"""
+	if label:
+		return f"{folder_name} - {label}{ext}"
+	return f"{folder_name}{ext}"
 
 def generate_unique_filename(dest_file, src_file=None):
 	"""Generate a unique filename by adding version numbers if conflicts occur.
@@ -39,6 +76,48 @@ def generate_unique_filename(dest_file, src_file=None):
 				return dest_file
 		except (OSError, IOError):
 			pass
+	
+	# Jellyfin multi-version naming: use ' - label' suffix instead of [Version N]
+	if is_jellyfin_multi_version_enabled() and os.path.islink(dest_file):
+		dir_path = os.path.dirname(dest_file)
+		folder_name = os.path.basename(dir_path)
+		ext = os.path.splitext(dest_file)[1]
+		
+		# Extract version label for the NEW file from source path
+		new_label = None
+		if src_file:
+			new_label = _extract_version_label(src_file)
+		if not new_label:
+			new_label = _extract_version_label(dest_file)
+		
+		# Rename the EXISTING symlink to also have a version label if it doesn't already
+		existing_basename = os.path.basename(dest_file)
+		existing_name_no_ext = os.path.splitext(existing_basename)[0]
+		# Check if existing file already has a Jellyfin version label (contains ' - ')
+		if ' - ' not in existing_name_no_ext or existing_name_no_ext == folder_name:
+			existing_target = get_symlink_target_path(dest_file)
+			if existing_target:
+				existing_label = _extract_version_label(existing_target)
+				if not existing_label:
+					existing_label = _extract_version_label(existing_basename)
+				if existing_label:
+					renamed_existing = os.path.join(dir_path, _jellyfin_version_name(folder_name, existing_label, ext))
+					if renamed_existing != dest_file and not os.path.exists(renamed_existing):
+						try:
+							os.rename(dest_file, renamed_existing)
+							log_message(f"Renamed existing file for Jellyfin multi-version: {existing_basename} -> {os.path.basename(renamed_existing)}", level="INFO")
+						except OSError as e:
+							log_message(f"Failed to rename existing file for Jellyfin versioning: {e}", level="WARNING")
+		
+		# Build the new file path with its version label
+		if new_label:
+			new_path = os.path.join(dir_path, _jellyfin_version_name(folder_name, new_label, ext))
+			# Avoid collision if same label already exists
+			if not os.path.exists(new_path):
+				return new_path
+			# If same label exists, fall through to standard versioning
+		
+		# If we couldn't extract labels, fall through to standard behavior
 	
 	# Check if version skipping is enabled
 	if is_skip_versions_enabled():

--- a/MediaHub/processors/symlink_utils.py
+++ b/MediaHub/processors/symlink_utils.py
@@ -17,34 +17,51 @@ from MediaHub.utils.plex_utils import update_plex_after_deletion
 from MediaHub.config.config import is_skip_versions_enabled, is_jellyfin_multi_version_enabled
 import re
 
-def _extract_version_label(filepath):
-	"""Extract a version label (resolution or edition) from a file path for Jellyfin multi-version naming.
+def _extract_version_parts(filepath):
+	"""Extract all version parts (resolution, quality source, edition) from a file path.
 	
-	Returns a label string like '2160p', '1080p', '720p', 'Remux', etc.
-	Falls back to a generic label if nothing can be extracted.
+	Returns a list of matched parts in priority order, e.g. ['1080p', 'BluRay'] or ['Extended'].
 	"""
 	basename = os.path.basename(filepath)
+	parts = []
 	
-	# Try to extract resolution (e.g., 2160p, 1080p, 720p, 480p)
+	# Resolution (e.g., 2160p, 1080p, 720p, 480p)
 	res_match = re.search(r'\b(2160p|1080p|720p|480p|360p|4K)\b', basename, re.IGNORECASE)
 	if res_match:
 		label = res_match.group(1)
-		# Normalize 4K to 2160p for consistent sorting
 		if label.upper() == '4K':
 			label = '2160p'
-		return label
+		parts.append(label)
 	
-	# Try to extract quality source (e.g., Remux, BluRay, WEB-DL, HDTV)
+	# Quality source (e.g., Remux, BluRay, WEB-DL, HDTV)
 	quality_match = re.search(r'\b(Remux|BluRay|Blu-Ray|WEB-DL|WEBRip|HDTV|HDRip|DVDRip|BDRip|BRRip)\b', basename, re.IGNORECASE)
 	if quality_match:
-		return quality_match.group(1)
+		parts.append(quality_match.group(1))
 	
-	# Try edition tags (e.g., Directors Cut, Extended, Theatrical)
+	# Edition tags (e.g., Directors Cut, Extended, Theatrical)
 	edition_match = re.search(r"\b(Director'?s?[\s.]?Cut|Extended|Theatrical|Unrated|Uncut|Remastered|IMAX)\b", basename, re.IGNORECASE)
 	if edition_match:
-		# Normalize dots/underscores to spaces in the label
-		return edition_match.group(1).replace('.', ' ').replace('_', ' ')
+		parts.append(edition_match.group(1).replace('.', ' ').replace('_', ' '))
 	
+	return parts
+
+def _extract_version_label(filepath):
+	"""Extract the best single version label from a file path.
+	
+	Returns the first matched part (resolution > quality > edition), or None.
+	"""
+	parts = _extract_version_parts(filepath)
+	return parts[0] if parts else None
+
+def _extract_detailed_version_label(filepath):
+	"""Extract a detailed version label combining all matched parts.
+	
+	Used as a fallback when the short label causes a conflict.
+	Returns e.g. '1080p BluRay', '1080p WEB-DL', or None if only one part (or none) matched.
+	"""
+	parts = _extract_version_parts(filepath)
+	if len(parts) > 1:
+		return ' '.join(parts)
 	return None
 
 def _jellyfin_version_name(folder_name, label, ext):

--- a/MediaHub/utils/config_defaults.py
+++ b/MediaHub/utils/config_defaults.py
@@ -91,6 +91,7 @@ def collect_defaults():
         "4K_SHOW_EXTRAS_SIZE_LIMIT": "800",
         "4K_MOVIE_EXTRAS_SIZE_LIMIT": "2048",
         "ALLOWED_EXTENSIONS": ".mp4,.mkv,.srt,.avi,.mov,.divx,.strm",
+        "JELLYFIN_MULTI_VERSION": "false",
         "SKIP_ADULT_PATTERNS": "true",
         "REPLACE_ILLEGAL_CHARACTERS": "true",
         "COLON_REPLACEMENT": "Smart Replace",

--- a/MediaHub/utils/keywords.json
+++ b/MediaHub/utils/keywords.json
@@ -1,4 +1,7 @@
 {
+    "resolutions": [
+        "2160p", "1080p", "720p", "480p", "360p", "4K"
+    ],
     "quality_sources": [
         "BluRay", "Blu-ray", "BD", "BDRip", "BRRip", "WEB-DL", "WEBDL", "WebRip", "WEBRip",
         "HDTV", "DVDRip", "DVDRIP", "REMUX", "BDRemux", "HYBRID"

--- a/WebDavHub/frontend/src/pages/SetupWizard.tsx
+++ b/WebDavHub/frontend/src/pages/SetupWizard.tsx
@@ -182,6 +182,7 @@ const wizardSteps: Step[] = [
       'ALLOWED_EXTENSIONS',
       'SKIP_ADULT_PATTERNS',
       'SKIP_VERSIONS',
+      'JELLYFIN_MULTI_VERSION',
     ],
   },
   {
@@ -653,6 +654,7 @@ export default function SetupWizard() {
     SKIP_EXTRAS_FOLDER: 'Skip processing extras folders.',
     SKIP_ADULT_PATTERNS: 'Skip files matching adult patterns.',
     SKIP_VERSIONS: 'Skip extra versions of the same release group (avoid Version 2/3 when only the group differs).',
+    JELLYFIN_MULTI_VERSION: 'Name multiple versions with Jellyfin-compatible labels (e.g. \' - 1080p\', \' - 2160p\') so Jellyfin groups them.',
     REPLACE_ILLEGAL_CHARACTERS: 'Replace illegal characters. If unchecked, MediaHub will remove them instead.',
     ENABLE_PLEX_UPDATE: 'Trigger Plex library updates after processing.',
     CINESYNC_AUTH_ENABLED: 'Require authentication for UI/API.',

--- a/WebDavHub/pkg/config/config.go
+++ b/WebDavHub/pkg/config/config.go
@@ -286,6 +286,7 @@ func getConfigDefinitions() []ConfigValue {
 		{Key: "ALLOWED_EXTENSIONS", Category: "File Handling Configuration", Type: "array", Required: false, Description: "Allowed file extensions for processing"},
 		{Key: "SKIP_ADULT_PATTERNS", Category: "File Handling Configuration", Type: "boolean", Required: false, Description: "Enable or disable skipping of specific file patterns"},
 		{Key: "SKIP_VERSIONS", Category: "File Handling Configuration", Type: "boolean", Required: false, Description: "Skip creating extra versions for the same release (avoids Version 2/3 when the release group is the only difference)"},
+		{Key: "JELLYFIN_MULTI_VERSION", Category: "File Handling Configuration", Type: "boolean", Required: false, Description: "Name multiple versions of the same movie with Jellyfin-compatible labels (e.g. ' - 1080p', ' - 2160p') so Jellyfin groups them as versions"},
 		{Key: "FILE_OPERATIONS_AUTO_MODE", Category: "File Handling Configuration", Type: "boolean", Required: false, Description: "Enable auto-processing mode for file operations", Hidden: true},
 		{Key: "REPLACE_ILLEGAL_CHARACTERS", Category: "File Handling Configuration", Type: "boolean", Required: false, Description: "Replace illegal characters. If unchecked, MediaHub will remove them instead"},
 		{Key: "COLON_REPLACEMENT", Category: "File Handling Configuration", Type: "select", Required: false, Description: "Colon replacement format", Options: []string{"Delete", "Replace with Dash", "Replace with Space Dash", "Replace with Space Dash Space", "Smart Replace"}},
@@ -804,6 +805,7 @@ func getConfigDefaults() map[string]string {
 		"ALLOWED_EXTENSIONS":         ".mp4,.mkv,.srt,.avi,.mov,.divx,.strm",
 		"SKIP_ADULT_PATTERNS":        "true",
 		"SKIP_VERSIONS":              "true",
+		"JELLYFIN_MULTI_VERSION":     "false",
 		"REPLACE_ILLEGAL_CHARACTERS": "true",
 		"COLON_REPLACEMENT":          "Smart Replace",
 		// Monitoring


### PR DESCRIPTION
# Add Jellyfin Multi-Version Movie Support

## Summary
Adds support for [Jellyfin's multi-version movie naming format](https://jellyfin.org/docs/general/server/media/movies/#multiple-versions), allowing multiple versions of the same movie (different resolutions, editions, or formats) to be grouped as a single library entry with a version picker.

## Problem
Previously, CineSync handled duplicate movies by either skipping them (SKIP_VERSIONS=true) or appending [Version N] suffixes. Neither approach integrates with Jellyfin's native multi-version grouping, which requires files named as:

`Movie Name (Year) [tmdbid-XXXXX]/` 
`Movie Name (Year) [tmdbid-XXXXX] - 1080p.mkv`
`Movie Name (Year) [tmdbid-XXXXX] - 2160p.mkv`

## Solution
A new JELLYFIN_MULTI_VERSION config option. When enabled, each movie file is named with a descriptive version label after the folder name, following Jellyfin's expected " - Label" convention.

When JELLYFIN_MULTI_VERSION is enabled, it takes precedence over SKIP_VERSIONS and [Version N] naming. The version label is always applied — even for the first/only file — so Jellyfin recognizes the format immediately when additional versions arrive.