### PR TITLE
fix(windows): use NTFS junctions instead of file-level symlinks for Plex compatibility

### DIFF
--- a/MediaHub/processors/symlink_creator.py
+++ b/MediaHub/processors/symlink_creator.py
@@ -44,6 +44,58 @@ db_initialized = False
 
 single_file_mode = False
 
+
+def _create_link_with_junction_fallback(link_target, dest_file):
+    """Create symlink, preferring NTFS junction on Windows when target resolves
+    to a directory (or to the zurg ``file-as-dir-then-file`` pattern).
+
+    On Windows, file-level symbolic links pointing at network/WebDAV mounts
+    (e.g. an rclone mount of a Real-Debrid WebDAV) are reported by the OS as
+    zero-length to applications. Plex Media Server reads ``Length=0`` and
+    silently drops the file from its scan. NTFS junctions (``mklink /J``) do
+    not have this limitation but only target directories, so we detect when
+    the source is a directory or matches the zurg wrapper pattern
+    (``Z:\\__all__\\<name>.mkv\\<name>.mkv``) and use a junction in those
+    cases. When the target is a file inside a multi-file release directory
+    (no wrapper), we fall back to ``os.symlink`` because there is no
+    safe single-file junction equivalent on NTFS targeting a remote mount.
+
+    On non-Windows platforms this function delegates to ``os.symlink``
+    unchanged. The signature matches ``os.symlink`` for drop-in use.
+    """
+    if os.name != 'nt':
+        os.symlink(link_target, dest_file)
+        return
+
+    import subprocess
+
+    resolved = link_target if os.path.isabs(link_target) else os.path.normpath(
+        os.path.join(os.path.dirname(dest_file), link_target)
+    )
+
+    junction_target = None
+    if os.path.isdir(resolved):
+        junction_target = resolved
+    else:
+        parent = os.path.dirname(resolved)
+        if parent and os.path.isdir(parent) and os.path.basename(parent) == os.path.basename(resolved):
+            junction_target = parent
+
+    if junction_target is not None:
+        if os.path.exists(dest_file):
+            try:
+                os.remove(dest_file)
+            except OSError:
+                pass
+        proc = subprocess.run(
+            ['cmd', '/c', 'mklink', '/J', dest_file, junction_target],
+            check=False, capture_output=True, text=True,
+        )
+        if proc.returncode == 0:
+            return
+
+    os.symlink(link_target, dest_file)
+
 class ProcessingManager:
     """Streaming manager that coordinates file processing with real-time analysis and dispatch"""
 
@@ -1327,7 +1379,7 @@ def process_file(args, force=False, batch_apply=False):
     # Create symlink
     try:
         link_target = _select_symlink_target(src_file, dest_file)
-        os.symlink(link_target, dest_file)
+        _create_link_with_junction_fallback(link_target, dest_file)
         log_message(f"Created symlink: {dest_file} -> {link_target}", level="INFO")
         log_message(f"Processed file: {src_file} to {dest_file}", level="INFO")
 
@@ -1470,7 +1522,7 @@ def process_file(args, force=False, batch_apply=False):
                 if existing_target and existing_target != normalized_src:
                     log_message(f"Detected source rename for existing symlink: {dest_file} -> {existing_target} (new: {normalized_src})", level="INFO")
                     if _safe_delete_symlink(dest_file):
-                        os.symlink(src_file, dest_file)
+                        _create_link_with_junction_fallback(src_file, dest_file)
                         update_source_path_for_destination(dest_file, src_file)
                         log_message(f"Updated symlink target and database for renamed source: {dest_file}", level="INFO")
                         return (dest_file, True, src_file)

--- a/MediaHub/processors/symlink_creator.py
+++ b/MediaHub/processors/symlink_creator.py
@@ -45,23 +45,10 @@ db_initialized = False
 single_file_mode = False
 
 
-def _create_link_with_junction_fallback(link_target, dest_file):
-    """Create symlink, preferring NTFS junction on Windows when target resolves
-    to a directory (or to the zurg ``file-as-dir-then-file`` pattern).
-
-    On Windows, file-level symbolic links pointing at network/WebDAV mounts
-    (e.g. an rclone mount of a Real-Debrid WebDAV) are reported by the OS as
-    zero-length to applications. Plex Media Server reads ``Length=0`` and
-    silently drops the file from its scan. NTFS junctions (``mklink /J``) do
-    not have this limitation but only target directories, so we detect when
-    the source is a directory or matches the zurg wrapper pattern
-    (``Z:\\__all__\\<name>.mkv\\<name>.mkv``) and use a junction in those
-    cases. When the target is a file inside a multi-file release directory
-    (no wrapper), we fall back to ``os.symlink`` because there is no
-    safe single-file junction equivalent on NTFS targeting a remote mount.
-
-    On non-Windows platforms this function delegates to ``os.symlink``
-    unchanged. The signature matches ``os.symlink`` for drop-in use.
+def _create_link_with_junction(link_target, dest_file):
+    """Create a symlink, but on Windows prefer an NTFS junction when the target is a
+    directory (or zurg's ``file-as-dir`` pattern): file-level symlinks on WebDAV mounts
+    read as zero-length and Plex drops them. Other cases and non-Windows use ``os.symlink``.
     """
     if os.name != 'nt':
         os.symlink(link_target, dest_file)
@@ -1379,7 +1366,7 @@ def process_file(args, force=False, batch_apply=False):
     # Create symlink
     try:
         link_target = _select_symlink_target(src_file, dest_file)
-        _create_link_with_junction_fallback(link_target, dest_file)
+        _create_link_with_junction(link_target, dest_file)
         log_message(f"Created symlink: {dest_file} -> {link_target}", level="INFO")
         log_message(f"Processed file: {src_file} to {dest_file}", level="INFO")
 
@@ -1522,7 +1509,7 @@ def process_file(args, force=False, batch_apply=False):
                 if existing_target and existing_target != normalized_src:
                     log_message(f"Detected source rename for existing symlink: {dest_file} -> {existing_target} (new: {normalized_src})", level="INFO")
                     if _safe_delete_symlink(dest_file):
-                        _create_link_with_junction_fallback(src_file, dest_file)
+                        _create_link_with_junction(src_file, dest_file)
                         update_source_path_for_destination(dest_file, src_file)
                         log_message(f"Updated symlink target and database for renamed source: {dest_file}", level="INFO")
                         return (dest_file, True, src_file)


### PR DESCRIPTION
## Problem

On Windows, file-level symbolic links (`os.symlink`) pointing at WebDAV/network mounts — such as an rclone mount of a Real-Debrid WebDAV exposing zurg's virtual filesystem — are reported by the OS as zero-length to applications.

**Plex Media Server reads `SymLen=0` and silently drops the file from its library scan.** The file simply does not appear in Plex even though:
- The symlink itself is well-formed.
- The underlying content via the rclone mount is readable.
- `os.stat` on the target reports the correct size.

This breaks the entire CineSync → Plex pipeline on Windows. Linux is unaffected because POSIX symlink semantics propagate correctly to Plex Linux.

## Fix

Introduce `_create_link_with_junction_fallback(link_target, dest_file)` that, on Windows only, prefers an NTFS junction (`mklink /J`) over an `os.symlink` when the target is a directory. Two patterns are detected:

1. **The link target resolves to a directory** — e.g. a release-dir wrapper. The junction points straight at it.
2. **The target is a file inside a same-named parent dir** — the `file-as-dir-then-file` pattern emitted by zurg, where `Z:\__all__\<name>.mkv\<name>.mkv` materializes a directory named like a file containing the actual file inside. The junction points at the parent dir; Plex resolves `<show>\Season X\<file>.mkv\<file>.mkv` transparently.

When neither case applies (the target is a file inside a multi-file release dir without the wrapper), the helper falls back to `os.symlink` — preserving existing behavior. Files that fall to the symlink fallback remain invisible to Plex Windows (the OS limitation cannot be worked around for that case via NTFS), but in real-world usage the release-dir junctions paralleled by Sonarr/Radarr cover the gap.

On **non-Windows platforms** the helper delegates to `os.symlink` unchanged. Linux/macOS behavior is unaffected.

## Changes

- New helper function `_create_link_with_junction_fallback` near the top of `symlink_creator.py` (50 lines, documented).
- Two call sites updated to use the helper:
  - `process_file` initial symlink creation (line ~1330)
  - `process_file` source-rename handler in the `FileExistsError` branch (line ~1473)

Net diff: +54 / -2 lines.

## Testing

Tested on Windows 10 22H2 with:
- rclone NSSM service mounting a Real-Debrid WebDAV at `Z:\`
- zurg as the WebDAV provider
- CineSync MediaHub processing `Z:\__all__\` → `C:\zurg\library\CineSync\{Movies,Shows}\`
- Plex Media Server (native Windows) indexing the CineSync output

**Before:** Movies and TV shows symlinked file-level appeared in CineSync's output dir but were silently absent from Plex (`Length=0` reported).

**After:** All eligible content materializes as NTFS junctions and is indexed by Plex correctly. The pipeline works end-to-end on Windows.

## Compatibility

- `subprocess` and `os` are already imported in the file; no new dependencies.
- `os.name == 'nt'` guard means Linux/macOS paths are byte-for-byte identical to before.
- Idempotent: if `dest_file` already exists, the helper removes it before retrying `mklink /J`.